### PR TITLE
GA: Use ruby/setup-ruby instead of actions/setup-ruby

### DIFF
--- a/.github/workflows/update_daily.yml
+++ b/.github/workflows/update_daily.yml
@@ -13,9 +13,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby 2.6
-      uses: actions/setup-ruby@v1
+      uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.6.x
+        ruby-version: '2.6'
+        bundler-cache: true
     - name: checkout aozorabuno.git
       run: |
         git clone --depth 1 https://github.com/aozorabunko/aozorabunko.git


### PR DESCRIPTION
`actions/setup-ruby`が動かなくなっていたようなので、`ruby/setup-ruby`に置き換えます。